### PR TITLE
Update tile action to use pending intent

### DIFF
--- a/wear/src/main/java/com/studio1a23/simplenote/tile/MainTileService.kt
+++ b/wear/src/main/java/com/studio1a23/simplenote/tile/MainTileService.kt
@@ -89,7 +89,10 @@ private fun editNotePendingIntent(context: Context): PendingIntent {
     )
     return TaskStackBuilder.create(context)
         .addNextIntentWithParentStack(editIntent)
-        .getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        .getPendingIntent(
+            0,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )!!
 }
 
 private fun tileLayout(

--- a/wear/src/main/java/com/studio1a23/simplenote/tile/MainTileService.kt
+++ b/wear/src/main/java/com/studio1a23/simplenote/tile/MainTileService.kt
@@ -4,7 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.TaskStackBuilder
-import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.tiles.ActionBuilders
 import androidx.wear.protolayout.ColorBuilders.argb
 import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.LayoutElementBuilders


### PR DESCRIPTION
## Summary
- create `PendingIntent` in `MainTileService` for navigating to edit screen
- launch `MainActivity` with that intent when tapping the tile
- remove unused click action handling code

## Testing
- `./gradlew :wear:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588a8428b48333a1c9b4c10b0583b6